### PR TITLE
Fixed Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,6 @@ let package = Package(
     ],
     dependencies: [],
     targets: [
-        .target(name: "UserDefaultsStore", dependencies: [])
+        .target(name: "UserDefaultsStore", dependencies: [], path: "Sources")
     ]
 )


### PR DESCRIPTION
SPM was complaining that the directory structure didn't match up, it's usually in the format `Sources/{Name}/*` instead of the current `Sources/*`. Updated the Package.swift file to target the right directory.